### PR TITLE
Minor fixes; Python upgraded to 3.12, iDRAC and WOL functional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder
-FROM python:3.11-slim AS builder
+FROM python:3.12-slim AS builder
 
 # Avoid interactive prompts
 ENV DEBIAN_FRONTEND=noninteractive
@@ -25,7 +25,7 @@ COPY . .
 RUN python -m compileall -q .
 
 # runner
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Set working directory
 WORKDIR /app

--- a/wolnut/client/__init__.py
+++ b/wolnut/client/__init__.py
@@ -141,7 +141,7 @@ class WolClientConfig(BaseClientConfig):
         Returns:
             bool: True if the packet was sent successfully, False otherwise.
         """
-        return send_wol_packet(self.mac, self.host)
+        return send_wol_packet(self.mac)
 
 
 @dataclass

--- a/wolnut/main.py
+++ b/wolnut/main.py
@@ -120,7 +120,7 @@ def main():
                                 client.name,
                                 client.type,
                             )
-                            if client.send_power_on():
+                            if client.send_power_on_signal():
                                 state_tracker.mark_wol_sent(client.name)
                         else:
                             logger.debug(


### PR DESCRIPTION
### Issues:
* ImportError: cannot import name 'override' from 'typing' (/usr/local/lib/python3.11/typing.py)
* AttributeError: 'WolClientConfig' object has no attribute 'send_power_on'
* WOL packets were sent to host IP instead of broadcast
### Fixes:
* Upgraded to Python3.12
* Client power-on method now uses correct attribute defined in WolClientConfig
* WOL now correctly sends packets by only using MAC address for broadcast
### Results:
* WOLNUT runs without errors
* Dell PowerEdge T620 with iDRAC7: successful power-on after UPS went on-line
* TrueNAS box: successful power-on using WOL